### PR TITLE
Update concurrent-model.md

### DIFF
--- a/docs/golang/core/concurrent/concurrent-model.md
+++ b/docs/golang/core/concurrent/concurrent-model.md
@@ -289,7 +289,6 @@ func producer(id int, jobs chan<- int, wg *sync.WaitGroup) {
 
 // 消费者函数从通道接收数据并处理
 func consumer(id int, jobs <-chan int, wg *sync.WaitGroup) {
-    defer wg.Done()
     for j := range jobs {
         fmt.Printf("Consumer %d processing job %d\n", id, j)
         time.Sleep(time.Second)
@@ -308,7 +307,6 @@ func main() {
 
     // 启动消费者 Goroutine
     for c := 1; c <= 2; c++ {
-        wg.Add(1)
         go consumer(c, jobs, &wg)
     }
 


### PR DESCRIPTION
修改了生产者-消费者模型代码示例：main函数创建consumers循环中的wg.Add(1)去掉；consumer函数中的defer部分去掉。原示例会造成死锁（main等待所有goroutine结束，而consumer goroutine需要close channel才能结束）

![image](https://github.com/user-attachments/assets/a3232f07-c2c1-40e7-ab88-6de384d5655a)
